### PR TITLE
Organize Depends/Suggests/Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,12 +20,13 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0
 Depends: 
     Biobase,
-    pkgdown,
     Rcpp
 Suggests: 
+    pkgdown,
     BiocStyle,
     knitr,
-    rmarkdown,
+    rmarkdown
+Imports:
     dagitty,
     DESeq2,
     edgeR,


### PR DESCRIPTION
Putting pkgdown in depends loads it for all users when loading the package, but it's not needed by the users, so I put it in Suggests. I moved everything needed by code in the vignette to Imports. All will be installed anyways because of the `dependencies=TRUE` flag in Dockerfile.